### PR TITLE
BUGFIX: Prevent 404 error with empty dimension segments

### DIFF
--- a/Classes/Package/FrontendNodeRoutePartHandler.php
+++ b/Classes/Package/FrontendNodeRoutePartHandler.php
@@ -16,6 +16,13 @@ class FrontendNodeRoutePartHandler extends NeosFrontendNodeRoutePartHandler
      * folder mixin type for hiding uri segement
      */
     const MIXIN_PROPERTY_NAME = 'hideSegmentInUriPath';
+
+    /**
+     * @Flow\InjectConfiguration("routing.supportEmptySegmentForDimensions", package="Neos.Neos")
+     * @var boolean
+     */
+    protected bool $supportEmptySegmentForDimensions;
+
     /**
      * @param string $requestPath
      * @return string


### PR DESCRIPTION
Without this change the handler tried to read the config from this package instead from the Neos core. Therefore the setting was always false.

Resolves: #10