### PR TITLE
[BUGFIX] Fixed bug on deeper folders throwing a 404

### DIFF
--- a/Classes/Package/FrontendNodeRoutePartHandler.php
+++ b/Classes/Package/FrontendNodeRoutePartHandler.php
@@ -85,6 +85,7 @@ class FrontendNodeRoutePartHandler extends NeosFrontendNodeRoutePartHandler
     ): ?NodeInterface {
         foreach ($startingNode->getChildNodes('Neos.Neos:Document') as $node) {
             if ($workspaceName === 'live' && $this->shouldHideNodeUriSegment($node)) {
+                $currentIndex = count($relativeNodePathSegments);
                 $foundNode = $this->findNextNodeWithPathSegmentRecursively(
                     $node,
                     $pathSegment,
@@ -92,7 +93,7 @@ class FrontendNodeRoutePartHandler extends NeosFrontendNodeRoutePartHandler
                     $workspaceName
                 );
                 if ($foundNode !== null) {
-                    array_unshift($relativeNodePathSegments, $node->getName());
+                    array_splice($relativeNodePathSegments, $currentIndex, 0, $node->getName());
                     return $foundNode;
                 }
             }


### PR DESCRIPTION
Deeper folders then on first level are not working and throwing a 404 error because of the array_unshift in the recursive function. I replaced it by array_splice and now it is also working on deeper levels