### PR TITLE
Alex second contribution

### DIFF
--- a/Classes/Eel/Helper/PackageManagerHelper.php
+++ b/Classes/Eel/Helper/PackageManagerHelper.php
@@ -1,0 +1,58 @@
+<?php
+namespace Breadlesscode\NodeTypes\Folder\Eel\Helper;
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Eel\ProtectedContextAwareInterface;
+use Neos\Flow\ObjectManagement\ObjectManagerInterface;
+use Neos\Flow\Package\Exception\UnknownPackageException;
+use Neos\Flow\Package\PackageManager;
+
+class PackageManagerHelper implements ProtectedContextAwareInterface
+{
+    /**
+     * @Flow\Inject
+     * @var ObjectManagerInterface
+     */
+    protected $objectManager;
+
+    /**
+     * @return string
+     */
+    public function getNeosUiMajorVersion()
+    {
+        return preg_replace('#^v?(\d+)\.(\d+)\.(\d+)$#', '$1', $this->getNeosUiVersion());
+    }
+
+    /**
+     * @return string
+     */
+    public function getNeosUiMinorVersion()
+    {
+        return preg_replace('#^v?(\d+)\.(\d+)\.(\d+)$#', '$1.$2', $this->getNeosUiVersion());
+    }
+
+    /**
+     * @return string
+     */
+    public function getNeosUiVersion()
+    {
+        try {
+            $packageManager = $this->objectManager->get(PackageManager::class);
+            $neosUiPackage = $packageManager->getPackage('Neos.Neos.Ui');
+            return $neosUiPackage->getInstalledVersion();
+        } catch (UnknownPackageException $e) {
+            return '0.0.0';
+        }
+    }
+
+    /**
+     * All methods are considered safe
+     *
+     * @param string $methodName
+     * @return boolean
+     */
+    public function allowsCallOfMethod($methodName)
+    {
+        return true;
+    }
+}

--- a/Classes/Eel/Helper/PackageManagerHelper.php
+++ b/Classes/Eel/Helper/PackageManagerHelper.php
@@ -18,7 +18,7 @@ class PackageManagerHelper implements ProtectedContextAwareInterface
     /**
      * @return string
      */
-    public function getNeosUiMajorVersion()
+    public function getNeosUiMajorVersion(): string
     {
         return preg_replace('#^v?(\d+)\.(\d+)\.(\d+)$#', '$1', $this->getNeosUiVersion());
     }
@@ -26,7 +26,7 @@ class PackageManagerHelper implements ProtectedContextAwareInterface
     /**
      * @return string
      */
-    public function getNeosUiMinorVersion()
+    public function getNeosUiMinorVersion(): string
     {
         return preg_replace('#^v?(\d+)\.(\d+)\.(\d+)$#', '$1.$2', $this->getNeosUiVersion());
     }
@@ -34,7 +34,7 @@ class PackageManagerHelper implements ProtectedContextAwareInterface
     /**
      * @return string
      */
-    public function getNeosUiVersion()
+    public function getNeosUiVersion(): string
     {
         try {
             $packageManager = $this->objectManager->get(PackageManager::class);
@@ -51,7 +51,7 @@ class PackageManagerHelper implements ProtectedContextAwareInterface
      * @param string $methodName
      * @return boolean
      */
-    public function allowsCallOfMethod($methodName)
+    public function allowsCallOfMethod($methodName): bool
     {
         return true;
     }

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -1,4 +1,7 @@
 Neos:
+  Fusion:
+    defaultContext:
+      'Breadlesscode.NodeTypes.Folder.PackageManager': 'Breadlesscode\NodeTypes\Folder\Eel\Helper\PackageManagerHelper'
   Neos:
     userInterface:
       translation:

--- a/Resources/Private/Fusion/Document/Folder.fusion
+++ b/Resources/Private/Fusion/Document/Folder.fusion
@@ -27,6 +27,7 @@ prototype(Breadlesscode.NodeTypes.Folder:Document.Folder) < prototype(Neos.Fusio
             body {
                 templatePath = 'resource://Breadlesscode.NodeTypes.Folder/Private/Templates/Folder.html'
                 title = ${q(node).property('title')}
+                version = ${Breadlesscode.NodeTypes.Folder.PackageManager.getNeosUiMajorVersion()}
             }
         }
     }

--- a/Resources/Private/Fusion/Document/Folder.fusion
+++ b/Resources/Private/Fusion/Document/Folder.fusion
@@ -26,7 +26,7 @@ prototype(Breadlesscode.NodeTypes.Folder:Document.Folder) < prototype(Neos.Fusio
             }
             body {
                 templatePath = 'resource://Breadlesscode.NodeTypes.Folder/Private/Templates/Folder.html'
-                title = ${q(node).property('title')}
+                title = ${q(documentNode).property('title')}
                 version = ${Breadlesscode.NodeTypes.Folder.PackageManager.getNeosUiMajorVersion()}
             }
         }
@@ -39,7 +39,7 @@ prototype(Breadlesscode.NodeTypes.Folder:Document.Folder) < prototype(Neos.Fusio
                 statusCode = 301
                 headers {
                     Location = Neos.Neos:NodeUri {
-                        node = ${q(documentNode).parent()}
+                        node = ${q(documentNode).parent().get(0)}
                     }
                 }
             }

--- a/Resources/Private/Fusion/Document/Folder.fusion
+++ b/Resources/Private/Fusion/Document/Folder.fusion
@@ -34,9 +34,14 @@ prototype(Breadlesscode.NodeTypes.Folder:Document.Folder) < prototype(Neos.Fusio
 
     default {
         condition = true
-        renderer = Neos.Neos:Page {
-            body = Neos.Neos:Shortcut {
-                targetMode = 'parentNode'
+        renderer = Neos.Fusion:Http.Message {
+            httpResponseHead {
+                statusCode = 301
+                headers {
+                    Location = Neos.Neos:NodeUri {
+                        node = ${q(documentNode).parent()}
+                    }
+                }
             }
         }
     }

--- a/Resources/Private/Templates/Folder.html
+++ b/Resources/Private/Templates/Folder.html
@@ -1,4 +1,4 @@
-<div id="breadlesscode-node-types-folder">
+<div id="breadlesscode-node-types-folder" class="btnf-neos-version-{version}">
     <div class="bntf-inner">
         <div class="bntf-icon"><i class="fas fa-folder"></i></div>
         <div class="bntf-title">{title}</div>

--- a/Resources/Public/Styles/Folder.css
+++ b/Resources/Public/Styles/Folder.css
@@ -6,14 +6,17 @@
     height: 100%;
     background-color: #222222;
     z-index: 9999;
-    /*
-    The Neos 7 backend normally uses the "Noto Sans" font,
-    which is no longer available as of 14 January 2023 in
-    the Neos.Neos package due to an incorrect file path in
-    Neos.css.
-    */
-    font-family: sans-serif;
+    font-family: "Noto Sans", sans-serif;
     -webkit-font-smoothing: antialiased;
+}
+
+/*
+The Neos backend normally uses the "Noto Sans" font,
+which is not available in Neos 5 due to an incorrect
+file path in Neos.css.
+*/
+#breadlesscode-node-types-folder.btnf-neos-version-5 {
+    font-family: sans-serif;
 }
 
 #breadlesscode-node-types-folder > div.bntf-inner {


### PR DESCRIPTION
Hi Marvin,

i handled the missing Noto Sans font in Neos 5 (for later Neos versions this will be fixed with this core [issue](https://github.com/neos/neos-development-collection/issues/4005)\) and the automatic redirection to the folder's parent page in the frontend, which was also mentioned in issue #19 of this project.

I tested the patch in Neos 7 and made code comparisons with Neos 4 to ensure backward compatibility.

Greetings
Alex