### PR TITLE
TASK: Use default "Noto Sans" font of Neos backend

### DIFF
--- a/Resources/Public/Styles/Folder.css
+++ b/Resources/Public/Styles/Folder.css
@@ -6,13 +6,7 @@
     height: 100%;
     background-color: #222222;
     z-index: 9999;
-    /*
-    The Neos 7 backend normally uses the "Noto Sans" font,
-    which is no longer available as of 14 January 2023 in
-    the Neos.Neos package due to an incorrect file path in
-    Neos.css.
-    */
-    font-family: sans-serif;
+    font-family: "Noto Sans", sans-serif;
     -webkit-font-smoothing: antialiased;
 }
 


### PR DESCRIPTION
Hi Marvin, hi Sebobo,

with this patch, the package uses Noto Sans font as default font again. The font was temporarily missing in Neos Core, which has been fixed with this patch https://github.com/neos/neos-development-collection/issues/4005.

Greetings
Alex