### PR TITLE
BUGFIX: Don't compare node objects directly but rather compare their paths

### DIFF
--- a/Classes/Package/FrontendNodeRoutePartHandler.php
+++ b/Classes/Package/FrontendNodeRoutePartHandler.php
@@ -139,7 +139,7 @@ class FrontendNodeRoutePartHandler extends NeosFrontendNodeRoutePartHandler
                 );
             }
 
-            if ($startingNode === $currentNode || !$this->shouldHideNodeUriSegment($currentNode)) {
+            if ($startingNode->getPath() === $currentNode->getPath() || !$this->shouldHideNodeUriSegment($currentNode)) {
                 $pathSegment = $currentNode->getProperty('uriPathSegment');
                 $requestPathSegments[] = $pathSegment;
             }


### PR DESCRIPTION
We use the mixin of your package on document nodes, that should actually be visible in the frontend. We just don't want their path segment in their childrens path.

However, if a path is generated to these pages, it would point to the parent page. The reason is, that you do compare if the starting node is the current node when checking if to consider the uri path segment or not. But you compare the objects instead of the path. One of the objects is put in a different context and thus, even though they are the same node, the equation returns false.

I changed it by checking if the paths are the same.