### PR TITLE
fix: Dont show Folders in StructuredData Breadcrumb

### DIFF
--- a/Resources/Private/Fusion/Overrides/Neos.Seo.StructuredData.Breadcrumb.fusion
+++ b/Resources/Private/Fusion/Overrides/Neos.Seo.StructuredData.Breadcrumb.fusion
@@ -1,0 +1,4 @@
+prototype(Neos.Seo:StructuredData.Breadcrumb){
+    // Dont show Folders in StructuredData Breadcrumb
+    items.@process.filterFolders = ${q(value).filter("[!instanceof Breadlesscode.NodeTypes.Folder:Document.Folder]").filter("[hideSegmentInUriPath!=true]").get()}
+}


### PR DESCRIPTION
Will prevent Folders (without URL) in Schema Breadcrumbs. 